### PR TITLE
Bugfix/fix populate sqlite

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Python version of Lift Pass Pricing Kata
 
-As with the other language versions, this exercise requires a database. There is a description in the [top level README](../README.md) of how to set up MySQL. If you don't have that, this version should fall back on sqlite3, and create a local database file 'lift_pass.db' in the directory where you run the application. Unfortunately the code doesn't actually work properly with sqlite3, so you'll have to adjust the SQL statements in prices.py.
+As with the other language versions, this exercise requires a database. There is a description in the [top level README](../README.md) of how to set up MySQL. If you don't have that, this version should fall back on sqlite3, and create a local database file 'lift_pass.db' in the directory where you run the application.
 
 For this python version you will also need to install the dependencies. I recommend you install them in a virtual environment like this:
 

--- a/python/src/db.py
+++ b/python/src/db.py
@@ -38,6 +38,7 @@ def try_to_connect_with_sqlite3(connection_options):
     ]
     for statement in create_statements:
         connection.execute(statement)
+        connection.commit()
 
     return connection
 


### PR DESCRIPTION
This fixes the issue where the sqlite database was not getting populated by anything other than the `base_price` table.

In sqlite, an `INSERT` statement implicitly opens a transaction, which needs to be committed before changes are saved in the database.

I added the `commit` command to do so and updated the documentation.