### PR TITLE
FIX: Holidays throw error "string has no attribute year"

### DIFF
--- a/python/src/prices.py
+++ b/python/src/prices.py
@@ -46,6 +46,8 @@ def prices():
                     holiday = row[0]
                     if "date" in request.args:
                         d = datetime.fromisoformat(request.args["date"])
+                        if not isinstance(holiday, datetime):
+                            holiday = datetime.fromisoformat(holiday)
                         if d.year == holiday.year and d.month == holiday.month and holiday.day == d.day:
                             is_holiday = True
                 if not is_holiday and "date" in request.args and datetime.fromisoformat(request.args["date"]).weekday() == 0:


### PR DESCRIPTION
When a request is for a day pass and has a date, the logic it tries to compare the request's date to the date that comes from the database.

However, when sqlite pulls data out of the database, it's a string. It needs to be converted to a `datetime` object.

This is one way to fix this issue. I'm very open to other suggestions.