### PR TITLE
FIX: Prevent adding the same data every time we connect to the database

### DIFF
--- a/python/src/db.py
+++ b/python/src/db.py
@@ -20,6 +20,16 @@ def create_lift_pass_db_connection(connection_options):
 def try_to_connect_with_sqlite3(connection_options):
     import sqlite3
     connection = sqlite3.connect("lift_pass.db")
+    try:
+        connection.execute(
+            'SELECT * FROM holidays '
+            'WHERE holiday = 2019-03-04'
+        )
+    except sqlite3.OperationalError:
+        pass
+    else:
+        return connection
+
     create_statements = [
         """CREATE TABLE IF NOT EXISTS base_price (
             pass_id INTEGER PRIMARY KEY AUTOINCREMENT,


### PR DESCRIPTION
Every time the code connects to a `sqlite` database, it adds the same data to the database.

This is one way to fix that by trying to query the last piece of data expected in the database. If it's there, it returns early. Otherwise it'll run the code to add all the data. 